### PR TITLE
Modified for NimBLE-Arduino v2.3.4

### DIFF
--- a/BleConnectionStatus.cpp
+++ b/BleConnectionStatus.cpp
@@ -6,9 +6,11 @@ BleConnectionStatus::BleConnectionStatus(void) {
 void BleConnectionStatus::onConnect(NimBLEServer* pServer)
 {
   this->connected = true;
+  Serial.println("BLE Device Connected!");
 }
 
 void BleConnectionStatus::onDisconnect(NimBLEServer* pServer)
 {
   this->connected = false;
+  Serial.println("BLE Device Disconnected!");
 }

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Changed the original [ESP32-BLE-Keyboard](https://github.com/T-vK/ESP32-BLE-Keyboard) to support NimBLE.
 
+Update [SP32-NimBLE-Keyboard](https://github.com/wakwak-koba/ESP32-NimBLE-Keyboard) to support NimBLE version 2.3.4.
+
 This library allows you to make the ESP32 act as a Bluetooth Keyboard and control what it does.  
 You might also be interested in:
 - [ESP32-NimBLE-Mouse](https://github.com/wakwak-koba/ESP32-NimBLE-Mouse)

--- a/library.properties
+++ b/library.properties
@@ -1,9 +1,9 @@
 name=ESP32 BLE Keyboard
-version=0.2.2
+version=0.0.1
 author=T-vK
 maintainer=T-vK
-sentence=Bluetooth LE Keyboard library for the ESP32.
-paragraph=Bluetooth LE Keyboard library for the ESP32.
+sentence=Bluetooth LE Keyboard library for the ESP32 modified for NimBLE-Arduino ver.2.3.4.
+paragraph=Bluetooth LE Keyboard library for the ESP32 modified for NimBLE-Arduino ver.2.3.4.
 category=Communication
-url=https://github.com/T-vK/ESP32-BLE-Keyboard
+url=https://github.com/tomorrow56/ESP32-NimBLE-Keyboard
 architectures=esp32

--- a/modified.md
+++ b/modified.md
@@ -1,0 +1,54 @@
+# ESP32-NimBLE-Keyboard ライブラリ修正内容
+
+## 概要
+ESP32-NimBLE-KeyboardライブラリをNimBLE-Arduino v2.3.4に対応させるための修正を実施。
+
+## 修正対象ファイル
+
+### 1. BleKeyboard.cpp
+**ファイルパス**: `ESP32-NimBLE-Keyboard/BleKeyboard.cpp`
+
+#### 修正内容:
+- **API名変更対応**:
+  - `inputReport()` → `getInputReport()`
+  - `outputReport()` → `getOutputReport()`
+  - `manufacturer()->setValue()` → `setManufacturer()`
+  - `setPnpId()` → `setPnp()`
+  - `hidInfo()` → `setHidInfo()`
+  - `reportMap()` → `setReportMap()`
+  - `hidService()` → `getHidService()`
+
+- **セキュリティ設定の変更**:
+  - `BLESecurity()` → `NimBLEDevice::setSecurityAuth()`
+  - `NimBLESecurity` インスタンス生成を廃止
+  - `NimBLEDevice::setSecurityPasskey()` を使用
+
+- **定数名変更**:
+  - `ESP_LE_AUTH_BOND` → `ESP_LE_AUTH_REQ_BOND`
+
+- **接続状態検出の改善**:
+  - `isConnected()` メソッドで `getConnectedCount()` を追加使用
+  - NimBLE-Arduino v2.3.4の新しいAPI対応
+
+#### 修正箇所 (行番号):
+- 108-116行: `isConnected()` メソッドの改善
+- 125-150行: `taskServer()` 内のAPI呼び出し修正
+
+### 2. BleConnectionStatus.cpp
+**ファイルパス**: `ESP32-NimBLE-Keyboard/BleConnectionStatus.cpp`
+
+#### 修正内容:
+- **デバッグ情報追加**:
+  - `onConnect()` に接続ログ出力を追加
+  - `onDisconnect()` に切断ログ出力を追加
+
+#### 修正箇所 (行番号):
+- 6-10行: `onConnect()` メソッドにデバッグ出力追加
+- 12-16行: `onDisconnect()` メソッドにデバッグ出力追加
+
+## 依存関係・環境
+
+- **NimBLE-Arduino ライブラリ**: v2.3.4 (最新)
+
+---
+**修正日**: 2025-08-16

--- a/modified_info.txt
+++ b/modified_info.txt
@@ -1,0 +1,32 @@
+SP32-NimBLE-KeyboardライブラリをNimBLE-Arduino v2.3.4に対応するよう修正しました。
+
+修正内容
+以下のAPI呼び出しを新しいバージョンに合わせて変更：
+
+inputReport() → getInputReport()
+outputReport() → getOutputReport()
+manufacturer()->setValue() → setManufacturer()
+pnp() → setPnpId()
+hidInfo() → setHidInfo()
+BLESecurity() → NimBLESecurity()
+ESP_LE_AUTH_BOND → ESP_LE_AUTH_REQ_BOND
+reportMap() → setReportMap()
+hidService() → getHidService()
+修正完了
+ESP32-NimBLE-KeyboardライブラリをNimBLE-Arduino v2.3.4に対応するよう修正しました。
+
+修正されたAPI呼び出し
+レポート取得メソッド：
+inputReport() → getInputReport()
+outputReport() → getOutputReport()
+デバイス設定メソッド：
+manufacturer()->setValue() → setManufacturer()
+pnp() → setPnpId()
+hidInfo() → setHidInfo()
+reportMap() → setReportMap()
+セキュリティ関連：
+BLESecurity() → NimBLESecurity()
+ESP_LE_AUTH_BOND → ESP_LE_AUTH_REQ_BOND
+サービス取得：
+hidService() → getHidService()
+これで、フォルダ内のESP32-NimBLE-KeyboardライブラリがNimBLE-Arduino v2.3.4と互換性を持つようになりました。Arduino IDEでコンパイルを実行して、エラーが解消されたことを確認してください。


### PR DESCRIPTION
Modification to make the ESP32-NimBLE-Keyboard library compatible with NimBLE-Arduino v2.3.4
- **Supported API name changes**:
- `inputReport()` → `getInputReport()`
- `outputReport()` → `getOutputReport()`
- `manufacturer()->setValue()` → `setManufacturer()`
- `setPnpId()` → `setPnp()`
- `hidInfo()` → `setHidInfo()`
- `reportMap()` → `setReportMap()`
- `hidService()` → `getHidService()`

- **Security setting changes**:
- `BLESecurity()` → `NimBLEDevice::setSecurityAuth()`
- Discontinued `NimBLESecurity` instance creation
- Use `NimBLEDevice::setSecurityPasskey()`

- **Constant name changes**:
- `ESP_LE_AUTH_BOND` → `ESP_LE_AUTH_REQ_BOND`

- **Improved connection status detection**:
- Added use of `getConnectedCount()` in the `isConnected()` method
- Supported the new API in NimBLE-Arduino v2.3.4

#### Modifications (line numbers):
- Lines 108-116: Improved the `isConnected()` method
- Lines 125-150: Fixed API calls in `taskServer()`